### PR TITLE
Add nav animations and image zoom

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,10 +8,12 @@
     <title>About Me - OaklandFlyer Photography</title>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="hex-bg.css">
     <script defer src="scroll.js"></script>
 </head>
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
+    <div id="hex-bg"></div>
     <header class="site-header">
         <a href="index.html" class="logo-link">
             <img src="images/TransparentLogo.png" alt="OaklandFlyer Logo">
@@ -56,7 +58,7 @@
     </footer>
 
     <script defer src="menuToggle.js"></script>
-
-
+    <script defer src="imageEnlarge.js"></script>
+    <script defer src="hex-bg.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -8,11 +8,13 @@
     <title>Contact - OaklandFlyer</title>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="hex-bg.css">
     <script defer src="scroll.js"></script>
 </head>
 
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
+    <div id="hex-bg"></div>
 
     <header class="site-header">
         <a href="index.html" class="logo-link">
@@ -70,5 +72,7 @@
     </footer>
 
     <script defer src="menuToggle.js"></script>
+    <script defer src="imageEnlarge.js"></script>
+    <script defer src="hex-bg.js"></script>
 </body>
 </html>

--- a/gallery-categories.html
+++ b/gallery-categories.html
@@ -8,10 +8,12 @@
   <title>Gallery Categories - OaklandFlyer Photography</title>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="hex-bg.css">
   <script defer src="scroll.js"></script>
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
+  <div id="hex-bg"></div>
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="images/TransparentLogo.png" alt="OaklandFlyer Logo">
@@ -71,5 +73,7 @@
   </footer>
 
   <script defer src="menuToggle.js"></script>
+  <script defer src="imageEnlarge.js"></script>
+  <script defer src="hex-bg.js"></script>
 </body>
 </html>

--- a/gallery.html
+++ b/gallery.html
@@ -6,6 +6,7 @@
   <title>Gallery - OaklandFlyer Photography</title>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="hex-bg.css" />
   <script defer src="scroll.js"></script>
   
   <style>
@@ -153,6 +154,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
+  <div id="hex-bg"></div>
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="images/TransparentLogo.png" alt="OaklandFlyer Logo">
@@ -443,5 +445,7 @@
     <p>&copy; 2025 OaklandFlyer LLC. All rights reserved.</p>
   </footer>
   <script defer src="menuToggle.js"></script>
+  <script defer src="imageEnlarge.js"></script>
+  <script defer src="hex-bg.js"></script>
 </body>
 </html>

--- a/imageEnlarge.js
+++ b/imageEnlarge.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const overlay = document.createElement('div');
+  overlay.id = 'img-overlay';
+  const img = document.createElement('img');
+  overlay.appendChild(img);
+  document.body.appendChild(overlay);
+
+  overlay.addEventListener('click', () => {
+    overlay.style.display = 'none';
+  });
+
+  document.querySelectorAll('img').forEach(el => {
+    el.setAttribute('draggable', 'false');
+    el.addEventListener('click', () => {
+      img.src = el.src;
+      overlay.style.display = 'flex';
+    });
+  });
+
+  document.addEventListener('contextmenu', e => {
+    if (e.target.tagName === 'IMG') {
+      e.preventDefault();
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@
   <script defer src="gallery.js"></script>
   <script defer src="scroll.js"></script>
   <script defer src="menuToggle.js"></script>
+  <script defer src="imageEnlarge.js"></script>
 
   <!-- Hexagon‐background script (deferred) -->
   <script defer src="hex-bg.js"></script>

--- a/products.html
+++ b/products.html
@@ -8,6 +8,7 @@
   <title>Products I Use - OaklandFlyer Photography</title>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="hex-bg.css">
   <script defer src="scroll.js"></script>
   <style>
     /* Fix for navigation overlap:
@@ -68,6 +69,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
+  <div id="hex-bg"></div>
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="images/TransparentLogo.png" alt="OaklandFlyer Logo">
@@ -153,5 +155,7 @@
   </footer>
 
   <script defer src="menuToggle.js"></script>
+  <script defer src="imageEnlarge.js"></script>
+  <script defer src="hex-bg.js"></script>
 </body>
 </html>

--- a/services.html
+++ b/services.html
@@ -8,6 +8,7 @@
   <title>Services - OaklandFlyer Photography</title>
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="hex-bg.css">
   <script defer src="scroll.js"></script>
   <style>
     /* Services Section Table Styles */
@@ -68,6 +69,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
+  <div id="hex-bg"></div>
   <header class="site-header">
     <a href="index.html" class="logo-link">
       <img src="images/TransparentLogo.png" alt="OaklandFlyer Logo">
@@ -177,5 +179,7 @@
   </footer>
 
   <script defer src="menuToggle.js"></script>
+  <script defer src="imageEnlarge.js"></script>
+  <script defer src="hex-bg.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -32,6 +32,11 @@ body {
   overflow-x: hidden;
 }
 
+img {
+  -webkit-user-drag: none;
+  user-select: none;
+}
+
 /* Hexagon Background */
 .hex-bg {
   position: fixed;
@@ -121,11 +126,13 @@ body {
 .site-nav {
   max-height: 0;
   overflow: hidden;
+  transform: translateY(-10px);
   opacity: 0;
-  transition: max-height 0.4s ease, opacity 0.3s ease;
+  transition: max-height 0.4s ease, opacity 0.3s ease, transform 0.4s ease;
   text-align: center;
 }
 .site-nav.open {
+  transform: translateY(0);
   max-height: 500px;
   opacity: 1;
 }
@@ -317,4 +324,22 @@ body {
 .fade-up.active {
   opacity: 1;
   transform: translateY(0);
+}
+/* Image overlay for enlarged view */
+#img-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+#img-overlay img {
+  max-width: 90%;
+  max-height: 90%;
+  border-radius: 8px;
 }

--- a/videos.html
+++ b/videos.html
@@ -8,11 +8,13 @@
     <title>Videos - OaklandFlyer</title>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="hex-bg.css">
     <script defer src="scroll.js"></script>
 </head>
 
 <body>
     <a href="#main" class="skip-link">Skip to content</a>
+    <div id="hex-bg"></div>
 
     <header class="site-header">
         <a href="index.html" class="logo-link">
@@ -58,6 +60,8 @@
     </footer>
 
     <script defer src="menuToggle.js"></script>
+    <script defer src="imageEnlarge.js"></script>
+    <script defer src="hex-bg.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- animate navigation sliding open
- disable image selection and show overlay when clicking images
- apply hexagon background across pages

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685c33594844832ca2c77c3ee23c24d9